### PR TITLE
Open browser window with localhost:[port]

### DIFF
--- a/style_transfer/cli.py
+++ b/style_transfer/cli.py
@@ -246,7 +246,7 @@ def main():
     callback = Callback(st, args, image_type=image_type, web_interface=web_interface)
     atexit.register(callback.close)
 
-    url = f'http://{args.host}:{args.port}/'
+    url = f'http://localhost:{args.port}/'
     if args.web:
         if args.browser:
             webbrowser.get(args.browser).open(url)


### PR DESCRIPTION
I noticed that the "--browser" flag does not function correctly and that, when the browser window is opened with the host IP, it returns an error. Changing the URL to localhost:[port] does the trick.